### PR TITLE
ビュー関連の微修正

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -1,4 +1,5 @@
 class PortfoliosController < ApplicationController
+  before_action :authenticate_cook!, except: :index
   before_action :set_portfolio, only: [:index, :update]
 
   def index

--- a/app/views/cooks/index.html.haml
+++ b/app/views/cooks/index.html.haml
@@ -6,8 +6,10 @@
         #{current_cook.nickname}さん
       - else
         ゲストさん
-      =link_to new_portfolio_path do
-        テスト用投稿
+    .cooks-top__middle-head__test
+      -if cook_signed_in?
+        =link_to new_portfolio_path do
+          テスト用投稿
     .cooks-top__middle-head__tabs
       .cooks-top__middle-head__tabs__pf.tab
         works

--- a/app/views/portfolios/_portfolio.html.haml
+++ b/app/views/portfolios/_portfolio.html.haml
@@ -6,11 +6,13 @@
       = "#{portfolio.title}"
     .cooks-top__contents__thumbnail__footer__utility
       %ul
-        %li
-          =link_to "編集", "/portfolios/#{portfolio.id}/edit", method: :get
-        %li
-          -# =link_to "詳細", show_portfolio_path
+        %li 
           詳細
-        %li
-          =link_to "削除", "/portfolios/#{portfolio.id}", method: :delete
+          -# =link_to "詳細", show_portfolio_path
+            詳細
+        -if cook_signed_in? && portfolio.cook_id == current_cook.id
+          %li
+            =link_to "編集", "/portfolios/#{portfolio.id}/edit", method: :get
+          %li
+            =link_to "削除", "/portfolios/#{portfolio.id}", method: :delete
     


### PR DESCRIPTION
#What
##未ログイン時にも出ていた投稿ページへのリンクを削除
##未ログイン者は一覧表示のみ可能にした
##編集、削除は投稿者のみリンクが出現するようにした

#Why
最低限のセキュリティであると考えるから。