### PR TITLE
タブ切り替え実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,5 +14,4 @@
 //= require activestorage
 //= require jquery
 //= require jquery_ujs
-//= require tabs
 //require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,5 @@
 //= require activestorage
 //= require jquery
 //= require jquery_ujs
-//= require_tree .
+//= require tabs
+//require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,13 +15,3 @@
 //= require jquery
 //= require jquery_ujs
 //= require_tree .
-$(function() {
-  $('.landing_page__contents__image_slicker').not('.slick-initialized').slick({
-    autoplay: true,
-    fade: true,
-    autoplaySpeed: 2000,
-    pauseOnHover: true,
-    arrows: false,
-    autoplaySpeed: 2000,
-  });
-});

--- a/app/assets/javascripts/slick.js
+++ b/app/assets/javascripts/slick.js
@@ -1,0 +1,10 @@
+$(function() {
+  $('.landing_page__contents__image_slicker').not('.slick-initialized').slick({
+    autoplay: true,
+    fade: true,
+    autoplaySpeed: 2000,
+    pauseOnHover: true,
+    arrows: false,
+    autoplaySpeed: 2000,
+  });
+});

--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -1,0 +1,11 @@
+jQuery(function($){
+	$('.tab').click(function(){
+		$('.is-active').removeClass('is-active');
+		$(this).addClass('is-active');
+		$('.is-show').removeClass('is-show');
+        // クリックしたタブからインデックス番号を取得
+		const index = $(this).index();
+        // クリックしたタブと同じインデックス番号をもつコンテンツを表示
+		$('.panel').eq(index).addClass('is-show');
+	});
+});

--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -1,11 +1,8 @@
-jQuery(function($){
-	$('.tab').click(function(){
-		$('.is-active').removeClass('is-active');
-		$(this).addClass('is-active');
-		$('.is-show').removeClass('is-show');
-        // クリックしたタブからインデックス番号を取得
-		const index = $(this).index();
-        // クリックしたタブと同じインデックス番号をもつコンテンツを表示
-		$('.panel').eq(index).addClass('is-show');
-	});
+$(function() {
+  $('.tab').on('click', function() {
+    $('.tab').removeClass("is-show");
+    $($(this).attr("href")).addClass("is-show");
+    $('.tab').removeClass('is-active');
+    $(this).addClass('is-active');
+  });
 });

--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -1,6 +1,7 @@
 $(function() {
+  /*クリックイベント*/
   $('.tab').on('click', function() {
-    $('.tab').removeClass("is-show");
+    $('.panel').removeClass("is-show");
     $($(this).attr("href")).addClass("is-show");
     $('.tab').removeClass('is-active');
     $(this).addClass('is-active');

--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -3,7 +3,7 @@ $(function() {
   $('.tab').on('click', function() {
     $('.panel').removeClass("is-show");
     $($(this).attr("href")).addClass("is-show");
-    $('.tab').removeClass('is-active');
+    $('.is-active').removeClass('is-active');
     $(this).addClass('is-active');
   });
 });

--- a/app/assets/stylesheets/cook_top.scss
+++ b/app/assets/stylesheets/cook_top.scss
@@ -23,7 +23,12 @@
           text-align: center;
           line-height: 45px;
         }
+        .is-active {
+          background-color: lightgray;
+          color: blue;
+        }
       }
+      
     }
   }
   &__contents {
@@ -32,6 +37,10 @@
       min-height: calc(100vh - 170px);
       min-width: 600px;
       margin: 0 30px;
+      display: none;
+    }
+    .is-show {
+      display: block;
     }
     &__portfolios {
       display: flex;

--- a/app/assets/stylesheets/cook_top.scss
+++ b/app/assets/stylesheets/cook_top.scss
@@ -40,14 +40,17 @@
     .panel.is-show {
       display: block;
     }
-    &__portfolios {
+    #cooks-top__contents__portfolios.panel.is-show{
       display: flex;
-      justify-content: flex-start;
+      justify-content:space-around;
       align-content: flex-start;
       flex-wrap: wrap;
+    }
+    &__portfolios {
       // サムネイル
       &__thumbnail {
         padding: 10px;
+        margin-right: 0px;
         width: 250px;
         border-width: 0px;
         &__img {

--- a/app/assets/stylesheets/cook_top.scss
+++ b/app/assets/stylesheets/cook_top.scss
@@ -26,53 +26,55 @@
       }
     }
   }
-  .panel {
-    background-color: lightgray;
-    min-height: calc(100vh - 170px);
-    min-width: 600px;
-    margin: 0 30px;
-  }
-  &__portfolios {
-    display: flex;
-    justify-content: flex-start;
-    align-content: flex-start;
-    flex-wrap: wrap;
-    // サムネイル
-    &__thumbnail {
-      padding: 10px;
-      width: 250px;
-      border-width: 0px;
-      &__img {
-        width: 100%;
-        height: 200px;
-        background-color: lightyellow;
-        > image {
-          margin: auto;
-          height: 100%;
-          max-height: 100%;
+  &__contents {
+    .panel {
+      background-color: lightgray;
+      min-height: calc(100vh - 170px);
+      min-width: 600px;
+      margin: 0 30px;
+    }
+    &__portfolios {
+      display: flex;
+      justify-content: flex-start;
+      align-content: flex-start;
+      flex-wrap: wrap;
+      // サムネイル
+      &__thumbnail {
+        padding: 10px;
+        width: 250px;
+        border-width: 0px;
+        &__img {
           width: 100%;
-          max-width: 100%;
+          height: 200px;
+          background-color: lightyellow;
+          > image {
+            margin: auto;
+            height: 100%;
+            max-height: 100%;
+            width: 100%;
+            max-width: 100%;
+          }
         }
-      }
-      &__footer {
-        background-color: white;
-        height: 80px;
-        text-decoration: none;
-        display: inline-block;
-        color: black;
-        width: 100%;
-        display: flex;
-        justify-content: space-between;
-        position: relative;
-        &__title {
+        &__footer {
+          background-color: white;
+          height: 80px;
+          text-decoration: none;
+          display: inline-block;
+          color: black;
+          width: 100%;
+          display: flex;
+          justify-content: space-between;
+          position: relative;
+          &__title {
 
-        }
-        &__utility {
-          position: absolute;
-          bottom: 5px;
-          right: 10px;
-          ul li {
-            list-style: none;
+          }
+          &__utility {
+            position: absolute;
+            bottom: 5px;
+            right: 10px;
+            ul li {
+              list-style: none;
+            }
           }
         }
       }

--- a/app/assets/stylesheets/cook_top.scss
+++ b/app/assets/stylesheets/cook_top.scss
@@ -11,25 +11,28 @@
       display: block;
     }
     &__tabs {
-      margin-right: 115px;
-      display: flex;
-      justify-content: flex-end;
-      .tab {
-        margin: 0 5px;
-        height: 45px;
-        width: 100px;
-        background-color: greenyellow;
-        text-align: center;
-        line-height: 45px;
+      ul {
+        margin-right: 115px;
+        display: flex;
+        justify-content: flex-end;
+        .tab {
+          margin: 0 5px;
+          height: 45px;
+          width: 100px;
+          background-color: greenyellow;
+          text-align: center;
+          line-height: 45px;
+        }
       }
     }
   }
-  &__contents {
+  .panel {
     background-color: lightgray;
     min-height: calc(100vh - 170px);
     min-width: 600px;
-    // max-width: 900px;;
     margin: 0 30px;
+  }
+  &__portfolios {
     display: flex;
     justify-content: flex-start;
     align-content: flex-start;

--- a/app/assets/stylesheets/cook_top.scss
+++ b/app/assets/stylesheets/cook_top.scss
@@ -11,7 +11,6 @@
       display: block;
     }
     &__tabs {
-      ul {
         margin-right: 115px;
         display: flex;
         justify-content: flex-end;
@@ -27,7 +26,6 @@
           background-color: lightgray;
           color: blue;
         }
-      }
       
     }
   }
@@ -39,7 +37,7 @@
       margin: 0 30px;
       display: none;
     }
-    .is-show {
+    .panel.is-show {
       display: block;
     }
     &__portfolios {

--- a/app/assets/stylesheets/module.scss
+++ b/app/assets/stylesheets/module.scss
@@ -24,3 +24,6 @@
     color: white;
   }
 }
+a {
+  text-decoration: none;
+}

--- a/app/views/cooks/index.html.haml
+++ b/app/views/cooks/index.html.haml
@@ -10,7 +10,7 @@
       -if cook_signed_in?
         =link_to new_portfolio_path do
           テスト用投稿
-    .cooks-top__middle-head__tabs
+    .cooks-top__middle-head__tabs.tab-group
       %ul
         %li.cooks-top__middle-head__tabs__pf.tab.is-active
           works
@@ -18,8 +18,9 @@
           articles
         %li.cooks-top__middle-head__tabs__prof.tab
           profile
-  .cooks-top__portfolios.panel.is-show
-    - @portfolios.each do |portfolio|
-      = render partial: "portfolios/portfolio", locals: { portfolio: portfolio }
-  .cooks-top__articles.panel
-  .cooks-top__profile.panel
+  .cooks-top__contents.panel-group
+    .cooks-top__contents__portfolios.panel.is-show
+      - @portfolios.each do |portfolio|
+        = render partial: "portfolios/portfolio", locals: { portfolio: portfolio }
+    .cooks-top__contents__articles.panel
+    .cooks-top__contents__profile.panel

--- a/app/views/cooks/index.html.haml
+++ b/app/views/cooks/index.html.haml
@@ -11,12 +11,15 @@
         =link_to new_portfolio_path do
           テスト用投稿
     .cooks-top__middle-head__tabs
-      .cooks-top__middle-head__tabs__pf.tab
-        works
-      .cooks-top__middle-head__tabs__ac.tab
-        articles
-      .cooks-top__middle-head__tabs__prof.tab
-        profile
-  .cooks-top__contents
+      %ul
+        %li.cooks-top__middle-head__tabs__pf.tab.is-active
+          works
+        %li.cooks-top__middle-head__tabs__ac.tab
+          articles
+        %li.cooks-top__middle-head__tabs__prof.tab
+          profile
+  .cooks-top__portfolios.panel.is-show
     - @portfolios.each do |portfolio|
       = render partial: "portfolios/portfolio", locals: { portfolio: portfolio }
+  .cooks-top__articles.panel
+  .cooks-top__profile.panel

--- a/app/views/cooks/index.html.haml
+++ b/app/views/cooks/index.html.haml
@@ -10,17 +10,20 @@
       -if cook_signed_in?
         =link_to new_portfolio_path do
           テスト用投稿
-    .cooks-top__middle-head__tabs.tab-group
-      %ul
-        %li.cooks-top__middle-head__tabs__pf.tab.is-active
-          works
-        %li.cooks-top__middle-head__tabs__ac.tab
-          articles
-        %li.cooks-top__middle-head__tabs__prof.tab
-          profile
+    .cooks-top__middle-head__tabs
+      %ul.tab-group
+        = link_to "#item1", class:".is-active" do
+          %li.cooks-top__middle-head__tabs__pf.tab.is-active
+            works
+        = link_to "#item2", class:"" do
+          %li.cooks-top__middle-head__tabs__ac.tab
+            articles
+        = link_to "#item3", class:"" do
+          %li.cooks-top__middle-head__tabs__prof.tab
+            profile
   .cooks-top__contents.panel-group
-    .cooks-top__contents__portfolios.panel.is-show
+    .cooks-top__contents__portfolios.panel.is-show#item1
       - @portfolios.each do |portfolio|
         = render partial: "portfolios/portfolio", locals: { portfolio: portfolio }
-    .cooks-top__contents__articles.panel
-    .cooks-top__contents__profile.panel
+    .cooks-top__contents__articles.panel#item2
+    .cooks-top__contents__profile.panel#item3

--- a/app/views/cooks/index.html.haml
+++ b/app/views/cooks/index.html.haml
@@ -11,19 +11,20 @@
         =link_to new_portfolio_path do
           テスト用投稿
     .cooks-top__middle-head__tabs
-      %ul.tab-group
-        = link_to "#item1", class:".is-active" do
-          %li.cooks-top__middle-head__tabs__pf.tab.is-active
-            works
-        = link_to "#item2", class:"" do
-          %li.cooks-top__middle-head__tabs__ac.tab
-            articles
-        = link_to "#item3", class:"" do
-          %li.cooks-top__middle-head__tabs__prof.tab
-            profile
+      = link_to "#cooks-top__contents__portfolios", class:"tab" do
+        .cooks-top__middle-head__tabs__pf.is-active
+          works
+      = link_to " #cooks-top__contents__articles", class:"tab" do
+        .cooks-top__middle-head__tabs__ac
+          articles
+      = link_to "#cooks-top__contents__profile", class:"tab" do
+        .cooks-top__middle-head__tabs__prof
+          profile
   .cooks-top__contents.panel-group
-    .cooks-top__contents__portfolios.panel.is-show#item1
+    #cooks-top__contents__portfolios.panel.is-show
       - @portfolios.each do |portfolio|
         = render partial: "portfolios/portfolio", locals: { portfolio: portfolio }
-    .cooks-top__contents__articles.panel#item2
-    .cooks-top__contents__profile.panel#item3
+    #cooks-top__contents__articles.panel
+      未実装
+    #cooks-top__contents__profile.panel
+      未実装

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,8 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'tabs', 'data-turbolinks-track': 'reload'
+
   %body
     = render "shared/header"
     = yield

--- a/app/views/layouts/lp.html.haml
+++ b/app/views/layouts/lp.html.haml
@@ -8,6 +8,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     %link{ rel: "stylesheet", type: "text/css", href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"}
     = javascript_include_tag 'application', data: { turbolinks: { track: true }}
+    = javascript_include_tag 'slick', data: { turbolinks: { track: true }}
     %script{type: "text/javascript",src: "https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"}
     %script{ type: "text/javascript", src: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"}
   %body

--- a/app/views/portfolios/_portfolio.html.haml
+++ b/app/views/portfolios/_portfolio.html.haml
@@ -1,10 +1,10 @@
-.cooks-top__portfolios__thumbnail
-  .cooks-top__portfolios__thumbnail__img
+.cooks-top__contents__portfolios__thumbnail
+  .cooks-top__contents__portfolios__thumbnail__img
     =image_tag portfolio.image1.url size: "250x200", class:"image"
-  .cooks-top__portfolios__thumbnail__footer
-    .cooks-top__portfolios__thumbnail__footer__title
+  .cooks-top__contents__portfolios__thumbnail__footer
+    .cooks-top__contents__portfolios__thumbnail__footer__title
       = "#{portfolio.title}"
-    .cooks-top__portfolios__thumbnail__footer__utility
+    .cooks-top__contents__portfolios__thumbnail__footer__utility
       %ul
         %li 
           詳細

--- a/app/views/portfolios/_portfolio.html.haml
+++ b/app/views/portfolios/_portfolio.html.haml
@@ -1,10 +1,10 @@
-.cooks-top__contents__thumbnail
-  .cooks-top__contents__thumbnail__img
+.cooks-top__portfolios__thumbnail
+  .cooks-top__portfolios__thumbnail__img
     =image_tag portfolio.image1.url size: "250x200", class:"image"
-  .cooks-top__contents__thumbnail__footer
-    .cooks-top__contents__thumbnail__footer__title
+  .cooks-top__portfolios__thumbnail__footer
+    .cooks-top__portfolios__thumbnail__footer__title
       = "#{portfolio.title}"
-    .cooks-top__contents__thumbnail__footer__utility
+    .cooks-top__portfolios__thumbnail__footer__utility
       %ul
         %li 
           詳細

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,3 +14,5 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w( slick.js )
+Rails.application.config.assets.precompile += %w( tabs.js )
+

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,3 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( slick.js )


### PR DESCRIPTION
#What
投稿作品一覧、記事一覧、プロフィールをタブメニュー切り替えにより表示させる。
意図しない表示↓
https://github.com/yamassx/mealfolio/issues/12
今回は解決にあたらず、先に他の機能を実装する。

＃Why
迅速に投稿物を確認し、管理することができると思われるから。